### PR TITLE
Map port 15600 to 15600 for node service

### DIFF
--- a/hornet-private-net/docker-compose.yml
+++ b/hornet-private-net/docker-compose.yml
@@ -33,6 +33,7 @@ services:
       - 15600
     ports:
       - "14265:14265"
+      - "15600:15600"
       - "8081:8081"
     volumes:
       - ./config/config-node.json:/app/config.json:ro


### PR DESCRIPTION
Signed-off-by: Peter Okwara <peter.okwara@outlook.com>

Fix an issue with private tangle. 

A remote hornet node was not connecting to a private tangle set up with the private_tangle.sh script. This is fixed by mapping docker's internal port 15600 to the system's port 15600.