### PR TITLE
Change amount of tokens to be minted for the snapshot address

### DIFF
--- a/hornet-private-net/private-tangle.sh
+++ b/hornet-private-net/private-tangle.sh
@@ -188,7 +188,7 @@ generateSnapshot () {
   # Generate the snapshot
   cd snapshots/private-tangle
   docker-compose run --rm -v "$PWD:/output_dir" node hornet tool snapgen "private-tangle"\
-   "$(cat ../../address.txt)" 2779530283277761 /output_dir/full_snapshot.bin
+   "$(cat ../../address.txt)" 1000000000 /output_dir/full_snapshot.bin
 
   echo "Initial Ed25519 Address generated. You can find the keys at key-pair.txt and the address at address.txt"
 


### PR DESCRIPTION
# Description of change

After creating a private tangle, the balance of the snapshot address is 0i. Which shouldn't be the case.

The private tangle scripts from gohornet repository has the initial amount allocated to **1000000000** https://github.com/gohornet/hornet/blob/e5716dd9db839a75d39c98b3856b29a9226a7a76/private_tangle/create_snapshot_private_tangle.sh#L14 while the script has the value set to the maximum amount **2779530283277761**

![unknown](https://user-images.githubusercontent.com/6847405/125412263-68222f80-e3c7-11eb-8456-97f96c4aa893.png)

Possible reasons why this happens is because, when using the value **2779530283277761** allocates all the tokens to the treasury and **0** tokens to the mint address.

 By setting the value other than **2779530283277761**, like **0**, will have **0** tokens allocated to the treasury and **2779530283277761** to the mint address. And with that we will have at least some balance in the mint address/snapshot address.

In this case, the value is set to **1000000000** to leave **1000000000** to the treasury and the rest  (2779530283277761 - 1000000000) to the mint address.

## Type of change

Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

1. Change the value of **2779530283277761** to **1000000000** at https://github.com/iotaledger/one-click-tangle/blob/chrysalis/hornet-private-net/private-tangle.sh#L191. this changes the total amount allocated to the treasury 

2. Install the private tangle.

3. Copy the snapshot address found in the address.txt file.

4. Paste the address in the explorer, found in localhost:8081

5. Check if the balance reflects the total maximum supply. 


## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
