### PR TITLE
Fix the format peers are added to the peering.json file

### DIFF
--- a/hornet-mainnet/hornet.sh
+++ b/hornet-mainnet/hornet.sh
@@ -93,7 +93,7 @@ peerSetup () {
     if [ -n "$peer" ]; then
         echo "Peering with: $peer"
         # This is the case where no previous peer definition was there
-        sed -i 's/\[\]/\[{"alias": "peer1"},{"multiAddress": "'$peer'"}\]/g' config/peering.json
+        sed -i 's/\[\]/\[{"alias": "peer1","multiAddress": "'$peer'"}\]/g' config/peering.json
         # This is the case for overwriting previous peer definition
         sed -i 's/{"multiAddress":\s\+".\+"}/{"multiAddress": "'$peer'"}/g' config/peering.json
     fi


### PR DESCRIPTION
# Description of change

An error shows up when trying to add peers via the command line

When the command
` ./hornet.sh install -p "\/ip4\/178.18.253.217\/tcp\/15600\/p2p\/12D3KooWMkDp22T9hPEz7mMaM9EgDGioiUiRxSiFKXBwt1mcHbpm" -i "gohornet\/hornet:1.0.3"` is run where `/ip4/178.18.253.217/tcp/15600/p2p/12D3KooWMkDp22T9hPEz7mMaM9EgDGioiUiRxSiFKXBwt1mcHbpm` is the peer address (_forward slashes have been added in the actual command so that sed can be able to process it without errors_)

An error shows up, saying **Invalid config peer address**

![image (11)](https://user-images.githubusercontent.com/6847405/127347441-c7daf572-fa21-44b8-87d4-5a0bf78cedaa.png)

This is because of the line https://github.com/iotaledger/one-click-tangle/blob/afb1bd878d2ad2a0c62fcfa423ffe24ce7f17300/hornet-mainnet/hornet.sh#L96 here there are two extra curly braces which mess up the peering.json configuration. 

Instead of the correct format, according to the documentation here https://hornet.docs.iota.org/post_installation/peering.html#adding-node-peers

```
{
   "peers":[
      {
         "alias":"peer1",
         "multiAddress":"/ip4/178.18.253.217/tcp/15600/p2p/12D3KooWMkDp22T9hPEz7mMaM9EgDGioiUiRxSiFKXBwt1mcHbpm"
      }
   ]
}
``` 

We have

```
{
   "peers":[
      {
         "alias":"peer1"
      },
      {
         "multiAddress":"/ip4/178.18.253.217/tcp/15600/p2p/12D3KooWMkDp22T9hPEz7mMaM9EgDGioiUiRxSiFKXBwt1mcHbpm"
      }
   ]
}
```

Which makes `alias` and `multiaddress` as two separate peers instead of one. This PR attempts to fix this issue.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

1. Clone the repository
2. Remove the existing **config.json** in the one-click-tangle/hornet-mainnet/config/config.json file and add the latest config file found [here](https://github.com/gohornet/hornet/blob/v1.0.3/config.json) 
3. Edit the config.json file to change the dasboard.bindAddress to  **0.0.0.0:8081** instead of **localhost:8081** and also change the **dashboard.auth.passwordHash** and the **dashboard.auth.passwordSalt** respectively so that you are able to log in to the dashboard.
4. Edit the **hornet.sh** file located in the **one-click-tangle/hornet-mainnet/** line https://github.com/iotaledger/one-click-tangle/blob/afb1bd878d2ad2a0c62fcfa423ffe24ce7f17300/hornet-mainnet/hornet.sh#L96 to `sed -i 's/\[\]/\[{"alias": "peer1","multiAddress": "'$peer'"}\]/g' config/peering.json
`
5. Install the hornet configuration by running ` ./hornet.sh install -p "\/ip4\/178.18.253.217\/tcp\/15600\/p2p\/12D3KooWMkDp22T9hPEz7mMaM9EgDGioiUiRxSiFKXBwt1mcHbpm" -i "gohornet\/hornet:1.0.3"` 
6. Check dashboard to see if the node is running, and the peer that you added exists in the peering.json file, and that the node is synching and after synching becomes healthy.

## Change checklist

- [x] I have performed a self-review of my own code

