### PR TITLE
Add notes on peer multiaddress and docker images

### DIFF
--- a/hornet-mainnet/README.md
+++ b/hornet-mainnet/README.md
@@ -20,6 +20,8 @@ The `peer_multiAddress` parameter must conform to the format specified [here](ht
 
 Optionally a Docker image name can be passed, even though, by default, the image name present in the `docker-compose.yaml` file will be used, usually `gohornet/hornet:latest`. 
 
+A back slash should be added wherever there is a forward slash. For example, when defining the docker image `gohornet/hornet:latest` should be `gohornet\/hornet:latest` and a peer multiaddress like `/ip4/x.x.x.x/tcp/15600/p2p/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx` should be `\/ip4\/x.x.x.x\/tcp\/15600\/p2p\/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx` to avoid any error occuring during running or installing hornet.
+
 * Stop Hornet by running
 ```
 ./hornet.sh stop


### PR DESCRIPTION
# Description of change

When installing a hornet node with the docker image option or with the peer multiAddress option as

`./hornet.sh install -p /ip4/x.x.x.x/tcp/15600/p2p/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx -i gohornet/hornet:latest`

An error shows up that states that

**sed: -e expression #1, char 30: unknown option to `s'**

![image (12)](https://user-images.githubusercontent.com/6847405/127358641-a9f20391-33b3-4a5c-871a-8592f864a8c3.png)

The cause of the error being the back slash found in the docker image and the peer multiAddress.

A way to avoid this error is adding forward slashes before a back slash. 

For example, a docker image or a peer multiaddress that looks like this `/ip4/x.x.x.x/tcp/15600/p2p/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx` and `gohornet/hornet:latest`

Can be formatted to look like this

`\/ip4\/x.x.x.x\/tcp\/15600\/p2p\/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx` and `gohornet\/hornet:latest`

The pull request seeks to alert the reader to this.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Documentation Fix

## How the change has been tested

The tests are closely related to the fix provided in the pull request https://github.com/iotaledger/one-click-tangle/pull/41#issue-698803741 as this pull request hasn't or may have not been merged yet

1. Clone the repository
2. Remove the existing **config.json** in the one-click-tangle/hornet-mainnet/config/config.json file and add the latest config file found [here](https://github.com/gohornet/hornet/blob/v1.0.3/config.json) 
3. Edit the config.json file to change the dasboard.bindAddress to  **0.0.0.0:8081** instead of **localhost:8081** and also change the **dashboard.auth.passwordHash** and the **dashboard.auth.passwordSalt** respectively so that you are able to log in to the dashboard.
4. Edit the **hornet.sh** file located in the **one-click-tangle/hornet-mainnet/** line https://github.com/iotaledger/one-click-tangle/blob/afb1bd878d2ad2a0c62fcfa423ffe24ce7f17300/hornet-mainnet/hornet.sh#L96 to `sed -i 's/\[\]/\[{"alias": "peer1","multiAddress": "'$peer'"}\]/g' config/peering.json
`
5. Install the hornet configuration by running ` ./hornet.sh install -p "\/ip4\/178.18.253.217\/tcp\/15600\/p2p\/12D3KooWMkDp22T9hPEz7mMaM9EgDGioiUiRxSiFKXBwt1mcHbpm" -i "gohornet\/hornet:1.0.3"` 
6. Check dashboard to see if the node is running, and the peer that you added exists in the peering.json file, and that the node is synching and after synching becomes healthy.

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation

