### PR TITLE
Fix typo in AWS documentation

### DIFF
--- a/hornet-mainnet/README_AWS.md
+++ b/hornet-mainnet/README_AWS.md
@@ -21,7 +21,7 @@ You can get access to the Hornet dashboard by opening on your Web Browser the fo
 The username and password of the dashboard application is `admin`. You can set a new password by executing
 
 ```console
-docker-compose run --rm hornet tool pwdhash 
+docker-compose run --rm hornet tool pwd-hash 
 ```
 and then edit the `config/config.json` file, changing the password hash and salt by the new values (under the  `dashboard` section). Afterwards you will need to restart Hornet by running: 
 


### PR DESCRIPTION
# Description of change

Typo in command for changing the password:

![1](https://user-images.githubusercontent.com/23168323/135296064-e898191b-62ea-4e8e-8fc9-b6279f008af3.png)

## Type of change

- Documentation Fix

## How the change has been tested

I ran the following command & it worked:

```console
docker-compose run --rm hornet tool pwd-hash 
```

## Change checklist

- [x] I have made corresponding changes to the documentation