### PR TITLE
Have identity resolver enabled by default

### DIFF
--- a/explorer/config/private-network.json
+++ b/explorer/config/private-network.json
@@ -1,5 +1,5 @@
 {
-  "network": "PrivateTangle",
+  "network": "tangle",
   "label": "Tangle",
   "provider": "http://node1:14265",
   "protocolVersion": "chrysalis",

--- a/explorer/config/webapp.config.local.json
+++ b/explorer/config/webapp.config.local.json
@@ -1,4 +1,5 @@
 {
-    "apiEndpoint": "http://localhost:4000",
-    "googleAnalyticsId": "GOOGLE-ANALYTICS-ID"
+  "apiEndpoint": "http://localhost:4000",
+  "googleAnalyticsId": "GOOGLE-ANALYTICS-ID",
+  "identityResolverEnabled": true
 }

--- a/hornet-private-net/README.md
+++ b/hornet-private-net/README.md
@@ -43,3 +43,9 @@ NB: The `update` command will not update to new versions of the config files as 
 * Add extra Nodes to your Private Tangle
 
 Go to the `extra-nodes` folder and follow the recipe [here](./extra-nodes/README.md). 
+
+## Notes on IOTA Frameworks
+
+If you want to use [IOTA Identity](https://github.com/identity.rs) on your Private Tangle you can do it by assigning the network identifier `tangle` to the DID method used, for instance `did:iota:tangle:F7PAPm2LqngmmN2uu3DSmHAvu74zA5f8c7c9R75qnMkG`. A DID generation Rust example can be found [here](https://github.com/iotaledger/identity.rs/blob/dev/examples/low-level-api/private_tangle.rs). 
+
+Note: If you install the Tangle Explorer the Identity Resolver will be enabled by default. The URL to inspect your generated DIDs will be typically of the form `http://localhost:8082/tangle/identity-resolver/{DID}`, for instance `http://localhost:8082/tangle/identity-resolver/did:iota:tangle:F7PAPm2LqngmmN2uu3DSmHAvu74zA5f8c7c9R75qnMkG`


### PR DESCRIPTION
# Description of change

The following pull request enables the IdentityResolver by default. The IdentityResolver helpes resolves DID's and closes #57 

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

### 1. The first step was setting up a private-tangle up and running with a short Network ID. Instead of `private-tangle` as the network name, we have `tangle` as the network name. This involves changes in several places in the one click tangle.

- The config file of the autopeering https://github.com/iotaledger/one-click-tangle/blob/d27af3e93e167b5efb6b2b155d610ce9764b5d46/hornet-private-net/config/config-autopeering.json#L29 the coordinator https://github.com/iotaledger/one-click-tangle/blob/d27af3e93e167b5efb6b2b155d610ce9764b5d46/hornet-private-net/config/config-coo.json#L61 the node https://github.com/iotaledger/one-click-tangle/blob/d27af3e93e167b5efb6b2b155d610ce9764b5d46/hornet-private-net/config/config-node.json#L62 the spammer https://github.com/iotaledger/one-click-tangle/blob/d27af3e93e167b5efb6b2b155d610ce9764b5d46/hornet-private-net/config/config-spammer.json#L61 need to be changed to `tangle`
- When setting up the snapshot, the network name needs to be changed from `private-tangle` to `tangle` here:  https://github.com/iotaledger/one-click-tangle/blob/d27af3e93e167b5efb6b2b155d610ce9764b5d46/hornet-private-net/private-tangle.sh#L193
- Run the private-tangle by running `./private-tangle.sh install 30`

### 2. Once the private tangle is running, the next step is to have the explorer up and running. Some things needed to be configured.

- Enable the Identity resolver here https://github.com/iotaledger/one-click-tangle/blob/chrysalis/explorer/config/webapp.config.local.json by adding the line ` "identityResolverEnabled": true`
- For some reason, if this is set as localhost, the client is unable to reach the api https://github.com/iotaledger/one-click-tangle/blob/d27af3e93e167b5efb6b2b155d610ce9764b5d46/explorer/tangle-explorer.sh#L80 if you get this error, change the location of the endpoint from `localhost` to `your ip address` in the line of code.
- Have the explorer installed and running by running the following command `./tangle-explorer.sh install ../hornet-private-net/` it should copy the network configuration automatically from the already running private-tangle, running within the same server/machine.
- If you click on the tools section, Identity resolver should show up as one of the tools with it's own dashboard. 
![image](https://user-images.githubusercontent.com/6847405/138696302-57c7acaf-50d5-42b5-8f46-3d6a290c862e.png)

### 3. To test if the identity resolver works, clone the identity.rs repository here https://github.com/iotaledger/identity.rs and we will modify one of the examples. Ensure you have rust installed. Go to the https://github.com/iotaledger/identity.rs/blob/dev/examples/account/create_did.rs file and modify the following lines

- For the config.rs code https://github.com/iotaledger/identity.rs/blob/dev/examples/account/config.rs change the network name, explorer url and the private node url
- Run the config.rs code by running `cargo run --example_config`
- You can click on the url generated or copy the did and check in the Identity resolver if it works

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
