### PR TITLE
First Hornet K8s StatefulSet PoC Working. Left to make peering persistent

### DIFF
--- a/k8s/hornet-config-map.yaml
+++ b/k8s/hornet-config-map.yaml
@@ -1,0 +1,222 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hornet-config
+data:
+  config.json: |
+    {
+      "restAPI": {
+        "jwtAuth": {
+          "enabled": false,
+          "salt": "HORNET"
+        },
+        "excludeHealthCheckFromAuth": false,
+        "permittedRoutes": [
+          "/health",
+          "/mqtt",
+          "/api/v1/info",
+          "/api/v1/tips",
+          "/api/v1/messages/:messageID",
+          "/api/v1/messages/:messageID/metadata",
+          "/api/v1/messages/:messageID/raw",
+          "/api/v1/messages/:messageID/children",
+          "/api/v1/messages",
+          "/api/v1/transactions/:transactionID/included-message",
+          "/api/v1/milestones/:milestoneIndex",
+          "/api/v1/milestones/:milestoneIndex/utxo-changes",
+          "/api/v1/outputs/:outputID",
+          "/api/v1/addresses/:address",
+          "/api/v1/addresses/:address/outputs",
+          "/api/v1/addresses/ed25519/:address",
+          "/api/v1/addresses/ed25519/:address/outputs",
+          "/api/v1/treasury"
+        ],
+        "whitelistedAddresses": [
+          "127.0.0.1",
+          "::1"
+        ],
+        "bindAddress": "0.0.0.0:14265",
+        "powEnabled": true,
+        "powWorkerCount": 1,
+        "limits": {
+          "bodyLength": "1M",
+          "maxResults": 1000
+        }
+      },
+      "dashboard": {
+        "bindAddress": "0.0.0.0:8081",
+        "auth": {
+          "sessionTimeout": "72h",
+          "username": "admin",
+          "passwordHash": "a4d321654d646f4035bb1aafa98f9f032587a277e76a997a9422a830b471eb90",
+          "passwordSalt": "c953f8eaf20f19531bc3403fee0ebb9b747ed2aeacf612b453307b0f68592e00"
+        }
+      },
+      "db": {
+        "engine": "rocksdb",
+        "path": "mainnetdb",
+        "autoRevalidation": false
+      },
+      "snapshots": {
+        "depth": 50,
+        "interval": 200,
+        "fullPath": "snapshots/mainnet/full_snapshot.bin",
+        "deltaPath": "snapshots/mainnet/delta_snapshot.bin",
+        "deltaSizeThresholdPercentage": 50,
+        "downloadURLs": [
+          {
+            "full": "https://chrysalis-dbfiles.iota.org/snapshots/hornet/latest-full_snapshot.bin",
+            "delta": "https://chrysalis-dbfiles.iota.org/snapshots/hornet/latest-delta_snapshot.bin"
+          }
+        ]
+      },
+      "pruning": {
+        "milestones": {
+          "enabled": false,
+          "maxMilestonesToKeep": 60480
+        },
+        "size": {
+          "enabled": true,
+          "targetSize": "30GB",
+          "thresholdPercentage": 10,
+          "cooldownTime": "5m"
+        },
+        "pruneReceipts": false
+      },
+      "protocol": {
+        "networkID": "chrysalis-mainnet",
+        "bech32HRP": "iota",
+        "minPoWScore": 4000,
+        "milestonePublicKeyCount": 2,
+        "publicKeyRanges": [
+          {
+            "key": "a9b46fe743df783dedd00c954612428b34241f5913cf249d75bed3aafd65e4cd",
+            "start": 0,
+            "end": 777600
+          },
+          {
+            "key": "365fb85e7568b9b32f7359d6cbafa9814472ad0ecbad32d77beaf5dd9e84c6ba",
+            "start": 0,
+            "end": 1555200
+          },
+          {
+            "key": "ba6d07d1a1aea969e7e435f9f7d1b736ea9e0fcb8de400bf855dba7f2a57e947",
+            "start": 552960,
+            "end": 2108160
+          },
+          {
+            "key": "760d88e112c0fd210cf16a3dce3443ecf7e18c456c2fb9646cabb2e13e367569",
+            "start": 1333460,
+            "end": 2888660
+          },
+          {
+            "key": "7bac2209b576ea2235539358c7df8ca4d2f2fc35a663c760449e65eba9f8a6e7",
+            "start": 2111060,
+            "end": 3666260
+          },
+          {
+            "key": "edd9c639a719325e465346b84133bf94740b7d476dd87fc949c0e8df516f9954",
+            "start": 2888660,
+            "end": 4443860
+          }
+        ]
+      },
+      "pow": {
+        "refreshTipsInterval": "5s"
+      },
+      "requests": {
+        "discardOlderThan": "15s",
+        "pendingReEnqueueInterval": "5s"
+      },
+      "receipts": {
+        "backup": {
+          "enabled": false,
+          "folder": "receipts"
+        },
+        "validator": {
+          "validate": false,
+          "api": {
+            "address": "http://localhost:14266",
+            "timeout": "5s"
+          },
+          "coordinator": {
+            "address": "UDYXTZBE9GZGPM9SSQV9LTZNDLJIZMPUVVXYXFYVBLIEUHLSEWFTKZZLXYRHHWVQV9MNNX9KZC9D9UZWZ",
+            "merkleTreeDepth": 24
+          }
+        }
+      },
+      "tangle": {
+        "milestoneTimeout": "30s"
+      },
+      "tipsel": {
+        "maxDeltaMsgYoungestConeRootIndexToCMI": 8,
+        "maxDeltaMsgOldestConeRootIndexToCMI": 13,
+        "belowMaxDepth": 15,
+        "nonLazy": {
+          "retentionRulesTipsLimit": 100,
+          "maxReferencedTipAge": "3s",
+          "maxChildren": 30,
+          "spammerTipsThreshold": 0
+        },
+        "semiLazy": {
+          "retentionRulesTipsLimit": 20,
+          "maxReferencedTipAge": "3s",
+          "maxChildren": 2,
+          "spammerTipsThreshold": 30
+        }
+      },
+      "node": {
+        "alias": "HORNET node - one-click-tangle",
+        "profile": "auto",
+        "disablePlugins": [],
+        "enablePlugins": [
+          "Autopeering"
+        ]
+      },
+      "p2p": {
+        "bindMultiAddresses": [
+          "/ip4/0.0.0.0/tcp/15600"
+        ],
+        "connectionManager": {
+          "highWatermark": 10,
+          "lowWatermark": 5
+        },
+        "gossipUnknownPeersLimit": 4,
+        "db": {
+          "path": "p2pstore"
+        },
+        "reconnectInterval": "30s",
+        "autopeering": {
+          "bindAddress": "0.0.0.0:14626",
+          "entryNodes": [
+            "/dns/lucamoser.ch/udp/14826/autopeering/4H6WV54tB29u8xCcEaMGQMn37LFvM1ynNpp27TTXaqNM",
+            "/dns/entry-hornet-0.h.chrysalis-mainnet.iotaledger.net/udp/14626/autopeering/iotaPHdAn7eueBnXtikZMwhfPXaeGJGXDt4RBuLuGgb",
+            "/dns/entry-hornet-1.h.chrysalis-mainnet.iotaledger.net/udp/14626/autopeering/iotaJJqMd5CQvv1A61coSQCYW9PNT1QKPs7xh2Qg5K2",
+            "/dns/entry-mainnet.tanglebay.com/udp/14626/autopeering/iot4By1FD4pFLrGJ6AAe7YEeSu9RbW9xnPUmxMdQenC"
+          ],
+          "entryNodesPreferIPv6": false,
+          "runAsEntryNode": false
+        }
+      },
+      "p2pdisc": {
+        "advertiseInterval": "30s",
+        "maxDiscoveredPeerConns": 4,
+        "rendezvousPoint": "between-two-vertices",
+        "routingTableRefreshPeriod": "60s"
+      },
+      "logger": {
+        "level": "debug",
+        "disableCaller": true,
+        "encoding": "console",
+        "outputPaths": [
+          "stdout"
+        ]
+      },
+      "warpsync": {
+        "advancementRange": 150
+      }
+    }
+  peering.json: |
+    {
+      "peers": []
+    }

--- a/k8s/hornet-service.yaml
+++ b/k8s/hornet-service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: hornet-tcp
+spec:
+  type: NodePort
+  externalTrafficPolicy: Local
+  ports:
+  - name: gossip
+    port: 15600
+    protocol: TCP
+    targetPort: gossip
+  - name: rest
+    port: 14265
+    protocol: TCP
+    targetPort: 14265
+  - name: dashboard
+    port: 8081
+    protocol: TCP
+    targetPort: dashboard
+  selector:
+    statefulset.kubernetes.io/pod-name: hornet-set-0

--- a/k8s/hornet.yaml
+++ b/k8s/hornet.yaml
@@ -1,0 +1,85 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: hornet-set
+spec:
+  serviceName: hornet-tcp
+  replicas: 1
+  selector:
+    matchLabels:
+      app: hornet
+  template:
+    metadata:
+      labels:
+        app: hornet
+    spec:
+      terminationGracePeriodSeconds: 10
+      initContainers:
+      - name: create-volumes
+        image: busybox
+        command:
+            - sh
+            - -c
+        args:
+            - >-
+                 echo "Hello"
+        volumeMounts:
+            - mountPath: /ledger/peering
+              name: hornet-ledger
+              subPath: peering
+      containers:
+      - name: hornet
+        image: gohornet/hornet:latest
+        workingDir: /app
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        resources:
+          requests:
+            memory: "100Mi"
+            cpu: "250m"
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 8081
+        ports:
+        - name: gossip
+          protocol: TCP
+          containerPort: 15600
+        - name: autopeering
+          protocol: UDP
+          containerPort: 14626
+        - name: rest
+          protocol: TCP
+          containerPort: 14265
+        - name: dashboard
+          protocol: TCP
+          containerPort: 8081
+        volumeMounts:
+        - name: configuration
+          mountPath: /app/config.json
+          subPath: config.json
+        - name: configuration
+          mountPath: /app/peering.json
+          subPath: peering.json
+        - name: hornet-ledger
+          subPath: mainnetdb
+          mountPath: /app/mainnetdb
+        - name: hornet-ledger
+          subPath: p2pstore
+          mountPath: /app/p2pstore
+        - name: hornet-ledger
+          subPath: snapshots
+          mountPath: /app/snapshots/mainnet
+      volumes:
+      - name: configuration 
+        configMap:
+          name: hornet-config
+  volumeClaimTemplates: 
+    - metadata: 
+        name: hornet-ledger
+      spec: 
+        accessModes: 
+          - ReadWriteOnce
+        resources: 
+          requests: 
+            storage: 100Mi


### PR DESCRIPTION
Just a PoC of an alternative design which is more elegant and compact than #59 . 
The config maps can be created just using kubectl through the existing hornet.sh utility functions. 
More work pending on testing this on a real K8s environment, such us GKS, or AWS. 
Tested on MicroK8s for MacOS. 

